### PR TITLE
fix: Allow pairing code generation when already logged in

### DIFF
--- a/src/usecase/app.go
+++ b/src/usecase/app.go
@@ -98,12 +98,6 @@ func (service serviceApp) LoginWithCode(ctx context.Context, phoneNumber string)
 		return loginCode, err
 	}
 
-	// detect is already logged in
-	if service.WaCli.Store.ID != nil {
-		logrus.Warn("User is already logged in")
-		return loginCode, pkgError.ErrAlreadyLoggedIn
-	}
-
 	// reconnect first
 	_ = service.Reconnect(ctx)
 


### PR DESCRIPTION
Removes the login check in the LoginWithCode use case. This allows a user to generate a pairing code to link a new device even if another session is already active, which is the intended behavior for this feature.

## Context
- Explain briefly the changes about

##  Test Results
<!--
- Attach the screenshot of the result or something
-->
- what you have done to test it